### PR TITLE
Nightwatch for Drupal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/README.md
+++ b/README.md
@@ -390,6 +390,22 @@ docker-compose exec test docker-as-drupal behat [options]
   -- <...>                 # any behat valid args
 ```
 
+*nightwatch* setup database and settings properly then run nightwatch command. `--group` is required
+as Drupal nitghtwatch tests doesn't pass without more config.
+
+Available options are:
+
+```bash
+docker-compose exec test docker-as-drupal nightwatch [options]
+
+  --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+  --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+  --with-dependencies      # Run composer and yarn install
+  --group=<group>          # Only runs tests from the specified group(s)
+  --help                   # Display behat help
+  -- <...>                 # any behat valid args
+```
+
 *phpunit* setup database and settings properly then run phpunit command including any options
 like file path, _--stop-on-failure_ or more.
 

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ docker-compose exec test docker-as-drupal behat [options]
 ```
 
 *nightwatch* setup database and settings properly then run nightwatch command. `--group` is required
-as Drupal nitghtwatch tests doesn't pass without more config.
+as Drupal nightwatch tests doesn't pass without more config.
 
 Available options are:
 

--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/5.6/node/8/Dockerfile
+++ b/php/5.6/node/8/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/5.6/node/8/scripts/docker-as-drupal
+++ b/php/5.6/node/8/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/5.6/scripts/docker-as-drupal
+++ b/php/5.6/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.0/Dockerfile
+++ b/php/7.0/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.0/node/10/Dockerfile
+++ b/php/7.0/node/10/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.0/node/10/scripts/docker-as-drupal
+++ b/php/7.0/node/10/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.0/node/8/Dockerfile
+++ b/php/7.0/node/8/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.0/node/8/scripts/docker-as-drupal
+++ b/php/7.0/node/8/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.0/scripts/docker-as-drupal
+++ b/php/7.0/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.1/Dockerfile
+++ b/php/7.1/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.1/node/10/Dockerfile
+++ b/php/7.1/node/10/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.1/node/10/scripts/docker-as-drupal
+++ b/php/7.1/node/10/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.1/node/11/Dockerfile
+++ b/php/7.1/node/11/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.1/node/11/scripts/docker-as-drupal
+++ b/php/7.1/node/11/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.1/node/12/Dockerfile
+++ b/php/7.1/node/12/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.1/node/12/scripts/docker-as-drupal
+++ b/php/7.1/node/12/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.1/node/8/Dockerfile
+++ b/php/7.1/node/8/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.1/node/8/scripts/docker-as-drupal
+++ b/php/7.1/node/8/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.1/node/9/Dockerfile
+++ b/php/7.1/node/9/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.1/node/9/scripts/docker-as-drupal
+++ b/php/7.1/node/9/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.1/scripts/docker-as-drupal
+++ b/php/7.1/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.2/Dockerfile
+++ b/php/7.2/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.2/node/10/Dockerfile
+++ b/php/7.2/node/10/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.2/node/10/scripts/docker-as-drupal
+++ b/php/7.2/node/10/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.2/node/11/Dockerfile
+++ b/php/7.2/node/11/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.2/node/11/scripts/docker-as-drupal
+++ b/php/7.2/node/11/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.2/node/12/Dockerfile
+++ b/php/7.2/node/12/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.2/node/12/scripts/docker-as-drupal
+++ b/php/7.2/node/12/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.2/node/8/Dockerfile
+++ b/php/7.2/node/8/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.2/node/8/scripts/docker-as-drupal
+++ b/php/7.2/node/8/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.2/node/9/Dockerfile
+++ b/php/7.2/node/9/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.2/node/9/scripts/docker-as-drupal
+++ b/php/7.2/node/9/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.2/scripts/docker-as-drupal
+++ b/php/7.2/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.3/Dockerfile
+++ b/php/7.3/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.3/node/10/Dockerfile
+++ b/php/7.3/node/10/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.3/node/10/scripts/docker-as-drupal
+++ b/php/7.3/node/10/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.3/node/11/Dockerfile
+++ b/php/7.3/node/11/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.3/node/11/scripts/docker-as-drupal
+++ b/php/7.3/node/11/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.3/node/12/Dockerfile
+++ b/php/7.3/node/12/Dockerfile
@@ -67,7 +67,7 @@ RUN set -ex; \
     imagemagick \
     jq \
     libpng-dev \
-    mysql-client \
+    mariadb-client \
     netcat \
     sudo \
     unzip \

--- a/php/7.3/node/12/scripts/docker-as-drupal
+++ b/php/7.3/node/12/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/php/7.3/scripts/docker-as-drupal
+++ b/php/7.3/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -115,6 +116,17 @@ function print_help() {
     --with-dependencies      # Run composer and yarn install
     --help                   # Display behat help
     -- <...>                 # any behat valid args
+
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --with-dependencies      # Run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
 
   * phpunit
 
@@ -849,6 +861,9 @@ elif [ "$1" = "behat" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -856,9 +871,6 @@ elif [ "$1" = "behat" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Rebuild Drupal cache
   drush cache-rebuild
@@ -897,6 +909,123 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=1
+  SKIP_STYLEGUIDE=1
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
+        ;;
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Set nightwatch custom Drupal config
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
+
+    # Install Nightwatch in the core directory
+    yarn install
+
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
+  nightwatch_exit=$?
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS
@@ -994,6 +1123,11 @@ elif [ "$1" = "phpunit" ]; then
     database_reset
   fi
 
+  if drupal_is_installed; then
+    # Enable modules that must be loaded for tests
+    drush en $TEST_ENABLE_MODULES -y
+  fi
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -1002,9 +1136,6 @@ elif [ "$1" = "phpunit" ]; then
   if drupal_is_installed; then
     # Disable modules that must not be loaded for tests
     drush pmu $TEST_DISABLE_MODULES -y
-
-    # Enable modules that must be loaded for tests
-    drush en $TEST_ENABLE_MODULES -y
 
     # Rebuild Drupal cache
     drush cache-rebuild

--- a/scripts/docker-as-drupal
+++ b/scripts/docker-as-drupal
@@ -979,7 +979,8 @@ elif [ "$1" = "nightwatch" ]; then
   drush pmu $TEST_DISABLE_MODULES -y
 
   # Set nightwatch custom Drupal config
-  for dir in $DRUPAL_NIGHTWATCH_CONFIG_SET; do
+  IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+  for config in "${configs[@]}"; do
     printf "\e[1;35m* config-setup ${config}.\e[0m\n"
     drush cset ${config} -y
   done

--- a/scripts/docker-as-drupal
+++ b/scripts/docker-as-drupal
@@ -968,6 +968,9 @@ elif [ "$1" = "nightwatch" ]; then
     database_reset
   fi
 
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
   # Load default content
   if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
     enable_default_content
@@ -975,9 +978,6 @@ elif [ "$1" = "nightwatch" ]; then
 
   # Disable modules that must not be loaded for tests
   drush pmu $TEST_DISABLE_MODULES -y
-
-  # Enable modules that must be loaded for tests
-  drush en $TEST_ENABLE_MODULES -y
 
   # Set nightwatch custom Drupal config
   for dir in $DRUPAL_NIGHTWATCH_CONFIG_SET; do

--- a/scripts/docker-as-drupal
+++ b/scripts/docker-as-drupal
@@ -982,7 +982,7 @@ elif [ "$1" = "nightwatch" ]; then
   drush cache-rebuild
 
   # Build styleguide
-  if yarn_is_installed && [ $SKIP_STYLEGUIDE -eq 0 ]; then
+  if [ $SKIP_STYLEGUIDE -eq 0 ]; then
     yarn build --production
   fi
 

--- a/scripts/docker-as-drupal
+++ b/scripts/docker-as-drupal
@@ -123,7 +123,6 @@ function print_help() {
 
     --skip-db-reset          # Do not reset database (to use only if database was reset just before)
     --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
-    --skip-styleguide-build  # Do not run yarn build
     --with-dependencies      # Run composer and yarn install
     --group=<group>          # Only runs tests from the specified group(s)
     --help                   # Display nightwatch help
@@ -918,7 +917,7 @@ elif [ "$1" = "nightwatch" ]; then
   shift
 
   SKIP_DEPENDENCIES=1
-  SKIP_STYLEGUIDE=0
+  SKIP_STYLEGUIDE=1
   SKIP_DB_RESET=0
   SKIP_DEFAULT_CONTENT=0
   NIGHTWATCH_GROUPS=()
@@ -929,8 +928,8 @@ elif [ "$1" = "nightwatch" ]; then
       --with-dependencies)
         SKIP_DEPENDENCIES=0
         ;;
-      --skip-styleguide-build)
-        SKIP_STYLEGUIDE=1
+      --with-styleguide)
+        SKIP_STYLEGUIDE=0
         ;;
       --skip-db-reset)
         SKIP_DB_RESET=1

--- a/scripts/docker-as-drupal
+++ b/scripts/docker-as-drupal
@@ -123,7 +123,7 @@ function print_help() {
     --skip-db-reset          # Do not reset database (to use only if database was reset just before)
     --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
     --skip-styleguide-build  # Do not run yarn build
-    --skip-dependencies      # Do not run composer and yarn install
+    --with-dependencies      # Run composer and yarn install
     --group=<group>          # Only runs tests from the specified group(s)
     --help                   # Display nightwatch help
     -- <...>                 # any nightwatch valid args
@@ -916,7 +916,7 @@ elif [ "$1" = "behat" ]; then
 elif [ "$1" = "nightwatch" ]; then
   shift
 
-  SKIP_DEPENDENCIES=0
+  SKIP_DEPENDENCIES=1
   SKIP_STYLEGUIDE=0
   SKIP_DB_RESET=0
   SKIP_DEFAULT_CONTENT=0
@@ -925,8 +925,8 @@ elif [ "$1" = "nightwatch" ]; then
 
   while [ $# -gt 0 ]; do
     case "$1" in
-      --skip-dependencies)
-        SKIP_DEPENDENCIES=1
+      --with-dependencies)
+        SKIP_DEPENDENCIES=0
         ;;
       --skip-styleguide-build)
         SKIP_STYLEGUIDE=1

--- a/scripts/docker-as-drupal
+++ b/scripts/docker-as-drupal
@@ -999,18 +999,17 @@ elif [ "$1" = "nightwatch" ]; then
   # Lock time
   lock_time
 
-  # move in core directory
-  cd web/core
+  # subshell to move in the web/core directory for installing & run tests
+  (
+    cd web/core
 
-  # Install Nightwatch in the core directory
-  yarn install
+    # Install Nightwatch in the core directory
+    yarn install
 
-  # Run tests
-  yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+    # Run tests
+    yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  )
   nightwatch_exit=$?
-
-  # move back in the root directory
-  cd ../../
 
   # Release time lock
   free_time

--- a/scripts/docker-as-drupal
+++ b/scripts/docker-as-drupal
@@ -116,6 +116,18 @@ function print_help() {
     --help                   # Display behat help
     -- <...>                 # any behat valid args
 
+  * nightwatch
+
+    Run nightwatch tests.
+
+    --skip-db-reset          # Do not reset database (to use only if database was reset just before)
+    --skip-default-content   # Do not load default content (maybe break the tests, ignored when db is reset)
+    --skip-styleguide-build  # Do not run yarn build
+    --skip-dependencies      # Do not run composer and yarn install
+    --group=<group>          # Only runs tests from the specified group(s)
+    --help                   # Display nightwatch help
+    -- <...>                 # any nightwatch valid args
+
   * phpunit
 
     Run phpunits tests.
@@ -897,6 +909,117 @@ elif [ "$1" = "behat" ]; then
 
   # exit
   exit $behat_exit
+
+#
+# RUN NIGHTWATCH TESTS
+#
+elif [ "$1" = "nightwatch" ]; then
+  shift
+
+  SKIP_DEPENDENCIES=0
+  SKIP_STYLEGUIDE=0
+  SKIP_DB_RESET=0
+  SKIP_DEFAULT_CONTENT=0
+  NIGHTWATCH_GROUPS=()
+  NIGHTWATCH_ARGV=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --skip-dependencies)
+        SKIP_DEPENDENCIES=1
+        ;;
+      --skip-styleguide-build)
+        SKIP_STYLEGUIDE=1
+        ;;
+      --skip-db-reset)
+        SKIP_DB_RESET=1
+        ;;
+      --skip-default-content)
+        SKIP_DEFAULT_CONTENT=1
+        ;;
+      --group=*)
+        NIGHTWATCH_GROUPS+=("--tag ${1#*=}")
+        ;;
+      --help)
+        print_help
+        yarn nightwatch --help
+        exit $?
+        ;;
+      --)
+        shift
+        NIGHTWATCH_ARGV=($@)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  # Install dependencies
+  if [ $SKIP_DEPENDENCIES -eq 0 ]; then
+    install_dependencies
+  fi
+
+  # Setup settings & Co.
+  setup
+
+  # Reset database
+  if [ $SKIP_DB_RESET -eq 0 ] || drupal_not_installed; then
+    database_reset
+  fi
+
+  # Load default content
+  if [ $SKIP_DEFAULT_CONTENT -eq 0 ]; then
+    enable_default_content
+  fi
+
+  # Disable modules that must not be loaded for tests
+  drush pmu $TEST_DISABLE_MODULES -y
+
+  # Enable modules that must be loaded for tests
+  drush en $TEST_ENABLE_MODULES -y
+
+  # Rebuild Drupal cache
+  drush cache-rebuild
+
+  # Build styleguide
+  if yarn_is_installed && [ $SKIP_STYLEGUIDE -eq 0 ]; then
+    yarn build --production
+  fi
+
+  # Lock time
+  lock_time
+
+  # move in core directory
+  cd web/core
+
+  # Install Nightwatch in the core directory
+  yarn install
+
+  # Run tests
+  yarn test:nightwatch ${NIGHTWATCH_GROUPS[@]} ${NIGHTWATCH_ARGV[@]}
+  nightwatch_exit=$?
+
+  # move back in the root directory
+  cd ../../
+
+  # Release time lock
+  free_time
+
+  # To not run this on CI
+  if is_development; then
+
+    # Disable default content
+    disable_default_content
+
+    # Disable modules that was loaded for tests
+    drush pmu $TEST_ENABLE_MODULES -y
+
+    # Re-enable disable modules
+    drush en $TEST_DISABLE_MODULES -y
+  fi
+
+  # exit
+  exit $nightwatch_exit
 
 #
 # RUN PHPUNIT TESTS

--- a/scripts/docker-as-drupal
+++ b/scripts/docker-as-drupal
@@ -979,14 +979,11 @@ elif [ "$1" = "nightwatch" ]; then
   # Enable modules that must be loaded for tests
   drush en $TEST_ENABLE_MODULES -y
 
-  if [ ! -z "$DRUPAL_NIGHTWATCH_CONFIG_SET" ]; then
-    IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
-    for config in "${configs[@]}"
-    do
-      printf "\e[1;35m* config-setup ${config}.\e[0m\n"
-      drush cset ${config} -y
-    done
-  fi
+  # Set nightwatch custom Drupal config
+  for dir in $DRUPAL_NIGHTWATCH_CONFIG_SET; do
+    printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+    drush cset ${config} -y
+  done
 
   # Rebuild Drupal cache
   drush cache-rebuild

--- a/scripts/docker-as-drupal
+++ b/scripts/docker-as-drupal
@@ -28,6 +28,7 @@ set -e
 : ${TEST_DISABLE_MODULES:="big_pipe"}
 : ${TEST_ENABLE_MODULES:=""}
 : ${TEST_USER:=""}
+: ${DRUPAL_NIGHTWATCH_CONFIG_SET:=""}
 
 # Script variables
 BROWSERTEST_OUTPUT_DIRECTORY="/var/www/web/sites/simpletest"
@@ -977,6 +978,15 @@ elif [ "$1" = "nightwatch" ]; then
 
   # Enable modules that must be loaded for tests
   drush en $TEST_ENABLE_MODULES -y
+
+  if [ ! -z "$DRUPAL_NIGHTWATCH_CONFIG_SET" ]; then
+    IFS=';' read -r -a configs <<< "$DRUPAL_NIGHTWATCH_CONFIG_SET"
+    for config in "${configs[@]}"
+    do
+      printf "\e[1;35m* config-setup ${config}.\e[0m\n"
+      drush cset ${config} -y
+    done
+  fi
 
   # Rebuild Drupal cache
   drush cache-rebuild

--- a/update.sh
+++ b/update.sh
@@ -120,7 +120,7 @@ function process {
   mkdir -p $DOCKERFILE_DIR/scripts
 
   # cleanup removed scripts
-  for file in `diff <(cd $(pwd)/scripts; find -s . -type f) <(cd $DOCKERFILE_DIR/scripts; find -s .  -type f) | grep "^>" | awk -F/ '{print "'"$DOCKERFILE_DIR/scripts/"'" $2}'`; do
+  for file in `diff <(cd $(pwd)/scripts; find . -type f | sort) <(cd $DOCKERFILE_DIR/scripts; find .  -type f | sort) | grep "^>" | awk -F/ '{print "'"$DOCKERFILE_DIR/scripts/"'" $2}'`; do
     (
       set -e
 
@@ -131,15 +131,14 @@ function process {
   done
 
   # copy Dockerfile template and scripts
-  cp ./Dockerfile $DOCKERFILE_PATH
   cp ./scripts/* $DOCKERFILE_DIR/scripts/
   chmod 774 $DOCKERFILE_DIR/scripts/*
 
   # update Dockerfile
-  sed -i '' \
+  sed \
     -e "s!%%PHP_VERSION%%!${phpVersion}!g" \
     -e "s!%%NODE_VERSION%%!${nodeVersion:-"false"}!g" \
-    "$DOCKERFILE_PATH"
+    ./Dockerfile > "$DOCKERFILE_PATH"
 
   # build docker imge if required
   if [ "$VERSION_TO_BUILD" = "all" ] || [ "$VERSION_TO_BUILD" = "$tag" ]; then

--- a/update.sh
+++ b/update.sh
@@ -130,11 +130,11 @@ function process {
     )
   done
 
-  # copy Dockerfile template and scripts
+  # copy scripts
   cp ./scripts/* $DOCKERFILE_DIR/scripts/
   chmod 774 $DOCKERFILE_DIR/scripts/*
 
-  # update Dockerfile
+  # copy Dockerfile
   sed \
     -e "s!%%PHP_VERSION%%!${phpVersion}!g" \
     -e "s!%%NODE_VERSION%%!${nodeVersion:-"false"}!g" \


### PR DESCRIPTION
I test this code with a mounted volume into Watchdreamer.

_docker-compose.override.yml_
```
  # Drupal test server
  test:
    hostname: test
    ports:
      - "8888:8888"
    volumes:
      - /Users/wengerk/www/contrib/docker/docker-php-dev/scripts/docker-as-drupal:/usr/local/bin/docker-as-drupal
```

I also suggest to change the codeshipsteps.yml to

```
>-
  bash -c "docker-as-wait --mysql test:8888 browser:4444 &&
    drush cset wd_test.settings mode 'nightwatch' -y &&
    docker-as-drupal nightwatch --group=wd"
```

But I'm maybe wrong, can we do that:

```
command: docker-as-wait --mysql test:8888 browser:4444 -- docker-as-drupal nightwatch --group=wd --skip-styleguide-build

```

I don't understand how to tests in a realife codeship instance.