### PR TITLE
Artifacts AWS S3 integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV APACHE_DOCUMENT_ROOT /var/www/web
 ENV NODE_MAJOR_VERSION %%NODE_VERSION%%
 
 ENV PATH="/var/www/node_modules/.bin:/var/www/vendor/bin:/var/www/bin:${PATH}"
+ENV ARTIFACTS_DEST="/usr/bin/artifacts"
 
 # Install dependencies
 RUN set -ex; \
@@ -94,6 +95,9 @@ RUN set -ex; \
     make install; \
   ); \
   rm -rf /usr/src/faketime; \
+  \
+  # Install artifacts
+  curl -fsSL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash; \
   \
   # cleanup
   apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/scripts/docker-as-artifacts
+++ b/scripts/docker-as-artifacts
@@ -58,12 +58,17 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-# Use default directory if not in present in arguements
+# Ensure both mandatory AWS S3 keys are fill.
+if [ -z "$ARTIFACTS_KEY" ] || [ -z "$ARTIFACTS_SECRET" ]; then
+  printf "\e[01;31m Error: You need to define env variables ARTIFACTS_KEY and ARTIFACTS_SECRET with S3 credentials.\e[0m\n"
+  exit 1
+fi
+
 if [ -z "$ARTIFACTS_DIR" ] && [ ! -z "$ARTIFACTS_DEFAULT_DIR" ]; then
   ARTIFACTS_DIR=("$ARTIFACTS_DEFAULT_DIR")
 fi
 
-# Use default AWS S3 if not in present in arguements
+# Use default AWS S3 if not in present in arguements.
 if [ -z "$ARTIFACTS_S3" ] && [ ! -z "$ARTIFACTS_DEFAULT_S3" ]; then
   ARTIFACTS_S3=("$ARTIFACTS_DEFAULT_S3")
 fi

--- a/scripts/docker-as-artifacts
+++ b/scripts/docker-as-artifacts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+: ${ARTIFACTS_INSTALL:="/usr/bin/artifacts-install"}
+: ${ARTIFACTS_LOG_DIR:="/var/www/log"}
+
+# Artifacts variables
+export ARTIFACTS_DEST=${ARTIFACTS_DEST:="/usr/bin/artifacts"}
+export ARTIFACTS_KEY=${ARTIFACTS_KEY:=""}
+export ARTIFACTS_SECRET=${ARTIFACTS_SECRET:=""}
+export ARTIFACTS_BUCKET=${ARTIFACTS_BUCKET:="codeship-artifact"}
+export ARTIFACTS_REGION=${ARTIFACTS_REGION:="eu-west-1"}
+
+# Download Artifacts installer.
+curl -sL -o "${ARTIFACTS_INSTALL}" \
+  "https://raw.githubusercontent.com/travis-ci/artifacts/master/install"
+
+# Make it executable & install Artifacts.
+chmod +x "${ARTIFACTS_INSTALL}"
+"${ARTIFACTS_INSTALL}"
+
+# Collect all files, then to upload them one by one.
+files="$(find -L ${ARTIFACTS_LOG_DIR} -type f)"
+echo "$files" | while read file; do
+  # Upload to Amazon S3.
+  "${ARTIFACTS_DEST}" upload \
+    --target-paths "${CI_REPO_NAME}/${CI_BUILD_NUMBER}/log" \
+    "${file}"
+done
+
+

--- a/scripts/docker-as-artifacts
+++ b/scripts/docker-as-artifacts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-: ${ARTIFACTS_INSTALL:="/usr/bin/artifacts-install"}
 : ${ARTIFACTS_DEFAULT_DIR:="/var/www/log"}
 : ${ARTIFACTS_DEFAULT_S3:="${CI_REPO_NAME}/${CI_BUILD_NUMBER}"}
 
@@ -20,7 +19,7 @@ function print_help() {
 
   --local-dir=<dir>        # Directory to upload on Amazone S3.
   --remote-dir=<dir>       # Directory name into Amazone S3.
-  --skip-install           # Do not install artifacts
+  --with-install           # Install artifacts
   --recursive              # Upload artifacts recursively
   -- <...>                 # Any artifacts valid args
   "
@@ -28,7 +27,7 @@ function print_help() {
 
 ARTIFACTS_DIR=()
 ARTIFACTS_S3=()
-SKIP_INSTALL=0
+SKIP_INSTALL=1
 RECURSIVE=0
 ARTIFACTS_ARGS=()
 while [ $# -gt 0 ]; do
@@ -39,8 +38,8 @@ while [ $# -gt 0 ]; do
     --remote-dir=*)
       ARTIFACTS_S3+=("${1#*=}")
       ;;
-    --skip-install)
-      SKIP_INSTALL=1
+    --with-install)
+      SKIP_INSTALL=0
       ;;
     --recursive)
       RECURSIVE=1
@@ -85,18 +84,13 @@ printf "\e[1;35m* bucket: ${ARTIFACTS_BUCKET}\e[0m\n"
 printf "\e[1;35m* region: ${ARTIFACTS_REGION}\e[0m\n"
 
 if [ $SKIP_INSTALL -eq 0 ]; then
-  printf "\n\e[1;35mDownload Artifacts into ${ARTIFACTS_INSTALL}.\e[0m\n"
+  printf "\n\e[1;35mDownload & Install Artifacts.\e[0m\n"
 
-  # Download Artifacts installer.
-  curl -sL -o "${ARTIFACTS_INSTALL}" \
-    "https://raw.githubusercontent.com/travis-ci/artifacts/master/install"
-
-  # Make it executable & install Artifacts.
-  chmod +x "${ARTIFACTS_INSTALL}"
-  "${ARTIFACTS_INSTALL}"
+  # Download Artifacts installer & install Artifacts in $ARTIFACTS_DEST.
+  curl -fsSL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
 fi
 
-printf "\n\e[1;35mUpload Artifacts from ${ARTIFACTS_DIR} to ${ARTIFACTS_S3}.\e[0m\n"
+printf "\n\e[1;35mUpload artifacts from ${ARTIFACTS_DIR} to ${ARTIFACTS_S3}.\e[0m\n"
 
 # Collect all files, then to upload them one by one.
 files="$(find -L ${ARTIFACTS_DIR} -type f)"

--- a/scripts/docker-as-artifacts
+++ b/scripts/docker-as-artifacts
@@ -28,7 +28,7 @@ function print_help() {
 ARTIFACTS_DIR=()
 ARTIFACTS_S3=()
 SKIP_INSTALL=1
-RECURSIVE=0
+MAXDEPTH="-maxdepth 1"
 ARTIFACTS_ARGS=()
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -42,7 +42,7 @@ while [ $# -gt 0 ]; do
       SKIP_INSTALL=0
       ;;
     --recursive)
-      RECURSIVE=1
+      MAXDEPTH=""
       ;;
     --help)
       print_help
@@ -93,7 +93,7 @@ fi
 printf "\n\e[1;35mUpload artifacts from ${ARTIFACTS_DIR} to ${ARTIFACTS_S3}.\e[0m\n"
 
 # Collect all files, then to upload them one by one.
-files="$(find -L ${ARTIFACTS_DIR} -type f)"
+files="$(find -L ${ARTIFACTS_DIR} ${MAXDEPTH} -type f)"
 echo "$files" | while read file; do
   if [ -f "${file}" ]; then
     # Upload to Amazon S3.

--- a/scripts/docker-as-artifacts
+++ b/scripts/docker-as-artifacts
@@ -6,7 +6,7 @@ set -e
 : ${ARTIFACTS_DEFAULT_S3:="${CI_REPO_NAME}/${CI_BUILD_NUMBER}"}
 
 # Artifacts variables
-: ${ARTIFACTS_BIN:="/usr/bin/artifacts"}
+export ARTIFACTS_DEST=${ARTIFACTS_BIN:="/usr/bin/artifacts"}
 export ARTIFACTS_KEY=${ARTIFACTS_KEY:=""}
 export ARTIFACTS_SECRET=${ARTIFACTS_SECRET:=""}
 export ARTIFACTS_BUCKET=${ARTIFACTS_BUCKET:="codeship-artifact"}

--- a/scripts/docker-as-artifacts
+++ b/scripts/docker-as-artifacts
@@ -2,30 +2,105 @@
 set -e
 
 : ${ARTIFACTS_INSTALL:="/usr/bin/artifacts-install"}
-: ${ARTIFACTS_LOG_DIR:="/var/www/log"}
+: ${ARTIFACTS_DEFAULT_DIR:="/var/www/log"}
+: ${ARTIFACTS_DEFAULT_S3:="${CI_REPO_NAME}/${CI_BUILD_NUMBER}"}
 
 # Artifacts variables
-export ARTIFACTS_DEST=${ARTIFACTS_DEST:="/usr/bin/artifacts"}
+: ${ARTIFACTS_BIN:="/usr/bin/artifacts"}
 export ARTIFACTS_KEY=${ARTIFACTS_KEY:=""}
 export ARTIFACTS_SECRET=${ARTIFACTS_SECRET:=""}
 export ARTIFACTS_BUCKET=${ARTIFACTS_BUCKET:="codeship-artifact"}
 export ARTIFACTS_REGION=${ARTIFACTS_REGION:="eu-west-1"}
 
-# Download Artifacts installer.
-curl -sL -o "${ARTIFACTS_INSTALL}" \
-  "https://raw.githubusercontent.com/travis-ci/artifacts/master/install"
+# Print help
+function print_help() {
+  echo "usage: $SCRIPT_NAME <dir> [options]
 
-# Make it executable & install Artifacts.
-chmod +x "${ARTIFACTS_INSTALL}"
-"${ARTIFACTS_INSTALL}"
+  Upload given artifacts directory into an Amazone S3 bucket.
+
+  --local-dir=<dir>        # Directory to upload on Amazone S3.
+  --remote-dir=<dir>       # Directory name into Amazone S3.
+  --skip-install           # Do not install artifacts
+  --recursive              # Upload artifacts recursively
+  -- <...>                 # Any artifacts valid args
+  "
+}
+
+ARTIFACTS_DIR=()
+ARTIFACTS_S3=()
+SKIP_INSTALL=0
+RECURSIVE=0
+ARTIFACTS_ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --local-dir=*)
+      ARTIFACTS_DIR+=("${1#*=}")
+      ;;
+    --remote-dir=*)
+      ARTIFACTS_S3+=("${1#*=}")
+      ;;
+    --skip-install)
+      SKIP_INSTALL=1
+      ;;
+    --recursive)
+      RECURSIVE=1
+      ;;
+    --help)
+      print_help
+      exit $?
+      ;;
+    --)
+      shift
+      ARTIFACTS_ARGS=($@)
+      break
+      ;;
+  esac
+  shift
+done
+
+# Use default directory if not in present in arguements
+if [ -z "$ARTIFACTS_DIR" ] && [ ! -z "$ARTIFACTS_DEFAULT_DIR" ]; then
+  ARTIFACTS_DIR=("$ARTIFACTS_DEFAULT_DIR")
+fi
+
+# Use default AWS S3 if not in present in arguements
+if [ -z "$ARTIFACTS_S3" ] && [ ! -z "$ARTIFACTS_DEFAULT_S3" ]; then
+  ARTIFACTS_S3=("$ARTIFACTS_DEFAULT_S3")
+fi
+
+# Remove any trailing slashes.
+ARTIFACTS_DIR=$(echo $ARTIFACTS_DIR | sed 's:/*$::')
+ARTIFACTS_S3=$(echo $ARTIFACTS_S3 | sed 's:/*$::')
+
+printf "\e[1;35m* Artifacts Setup.\e[0m\n"
+printf "\e[1;35m* local: ${ARTIFACTS_DIR}\e[0m\n"
+printf "\e[1;35m* remote: aws::${ARTIFACTS_S3}\e[0m\n"
+printf "\e[1;35m* bucket: ${ARTIFACTS_BUCKET}\e[0m\n"
+printf "\e[1;35m* region: ${ARTIFACTS_REGION}\e[0m\n"
+
+if [ $SKIP_INSTALL -eq 0 ]; then
+  printf "\n\e[1;35m* Download Artifacts into ${ARTIFACTS_INSTALL}.\e[0m\n"
+
+  # Download Artifacts installer.
+  curl -sL -o "${ARTIFACTS_INSTALL}" \
+    "https://raw.githubusercontent.com/travis-ci/artifacts/master/install"
+
+  # Make it executable & install Artifacts.
+  chmod +x "${ARTIFACTS_INSTALL}"
+  "${ARTIFACTS_INSTALL}"
+fi
+
+printf "\n\e[1;35m* Upload Artifacts from ${ARTIFACTS_DIR} to ${ARTIFACTS_S3}.\e[0m\n"
 
 # Collect all files, then to upload them one by one.
-files="$(find -L ${ARTIFACTS_LOG_DIR} -type f)"
+files="$(find -L ${ARTIFACTS_DIR} -type f)"
 echo "$files" | while read file; do
-  # Upload to Amazon S3.
-  "${ARTIFACTS_DEST}" upload \
-    --target-paths "${CI_REPO_NAME}/${CI_BUILD_NUMBER}/log" \
-    "${file}"
+  if [ -f "${file}" ]; then
+    # Upload to Amazon S3.
+    "${ARTIFACTS_BIN}" upload \
+      --target-paths "${ARTIFACTS_S3}" \
+      "${file}" "${ARTIFACTS_ARGS[@]}"
+  fi
 done
 
 

--- a/scripts/docker-as-artifacts
+++ b/scripts/docker-as-artifacts
@@ -64,6 +64,7 @@ if [ -z "$ARTIFACTS_KEY" ] || [ -z "$ARTIFACTS_SECRET" ]; then
   exit 1
 fi
 
+# Use default directory if not in present in arguements.
 if [ -z "$ARTIFACTS_DIR" ] && [ ! -z "$ARTIFACTS_DEFAULT_DIR" ]; then
   ARTIFACTS_DIR=("$ARTIFACTS_DEFAULT_DIR")
 fi
@@ -77,14 +78,14 @@ fi
 ARTIFACTS_DIR=$(echo $ARTIFACTS_DIR | sed 's:/*$::')
 ARTIFACTS_S3=$(echo $ARTIFACTS_S3 | sed 's:/*$::')
 
-printf "\e[1;35m* Artifacts Setup.\e[0m\n"
+printf "\e[1;35mArtifacts Setup.\e[0m\n"
 printf "\e[1;35m* local: ${ARTIFACTS_DIR}\e[0m\n"
 printf "\e[1;35m* remote: aws::${ARTIFACTS_S3}\e[0m\n"
 printf "\e[1;35m* bucket: ${ARTIFACTS_BUCKET}\e[0m\n"
 printf "\e[1;35m* region: ${ARTIFACTS_REGION}\e[0m\n"
 
 if [ $SKIP_INSTALL -eq 0 ]; then
-  printf "\n\e[1;35m* Download Artifacts into ${ARTIFACTS_INSTALL}.\e[0m\n"
+  printf "\n\e[1;35mDownload Artifacts into ${ARTIFACTS_INSTALL}.\e[0m\n"
 
   # Download Artifacts installer.
   curl -sL -o "${ARTIFACTS_INSTALL}" \
@@ -95,7 +96,7 @@ if [ $SKIP_INSTALL -eq 0 ]; then
   "${ARTIFACTS_INSTALL}"
 fi
 
-printf "\n\e[1;35m* Upload Artifacts from ${ARTIFACTS_DIR} to ${ARTIFACTS_S3}.\e[0m\n"
+printf "\n\e[1;35mUpload Artifacts from ${ARTIFACTS_DIR} to ${ARTIFACTS_S3}.\e[0m\n"
 
 # Collect all files, then to upload them one by one.
 files="$(find -L ${ARTIFACTS_DIR} -type f)"


### PR DESCRIPTION
suggestion of ameliorations

- add `--help`
- add `--dir` parameter instead of `ARTIFACTS_LOG_DIR`

to use artifact, please add the following keys to your `docker-compose.override.yml`
```
      ARTIFACTS_KEY: (see 1password)
      ARTIFACTS_SECRET: (see 1password)
      ARTIFACTS_BUCKET: (see 1password)
      ARTIFACTS_LOG_DIR: /var/www/log
```

You may not use the `ARTIFACTS_LOG_DIR` and use the option `--local-dir` 