### PR TITLE
Add INTL extension

### DIFF
--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
     libpng-dev \
     libpq-dev \
     libzip-dev \
+    libicu-dev \
   ; \
   \
   # install the PHP extensions we need
@@ -37,6 +38,7 @@ RUN set -ex; \
     pdo_mysql \
     pdo_pgsql \
     zip \
+    intl \
   ; \
   \
   # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/php/7.0/Dockerfile
+++ b/php/7.0/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
     libpng-dev \
     libpq-dev \
     libzip-dev \
+    libicu-dev \
   ; \
   \
   # install the PHP extensions we need
@@ -37,6 +38,7 @@ RUN set -ex; \
     pdo_mysql \
     pdo_pgsql \
     zip \
+    intl \
   ; \
   \
   # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/php/7.1/Dockerfile
+++ b/php/7.1/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
     libpng-dev \
     libpq-dev \
     libzip-dev \
+    libicu-dev \
   ; \
   \
   # install the PHP extensions we need
@@ -37,6 +38,7 @@ RUN set -ex; \
     pdo_mysql \
     pdo_pgsql \
     zip \
+    intl \
   ; \
   \
   # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/php/7.2/Dockerfile
+++ b/php/7.2/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
     libpng-dev \
     libpq-dev \
     libzip-dev \
+    libicu-dev \
   ; \
   \
   # install the PHP extensions we need
@@ -37,6 +38,7 @@ RUN set -ex; \
     pdo_mysql \
     pdo_pgsql \
     zip \
+    intl \
   ; \
   \
   # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/php/7.3/Dockerfile
+++ b/php/7.3/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
     libpng-dev \
     libpq-dev \
     libzip-dev \
+    libicu-dev \
   ; \
   \
   # install the PHP extensions we need
@@ -37,6 +38,7 @@ RUN set -ex; \
     pdo_mysql \
     pdo_pgsql \
     zip \
+    intl \
   ; \
   \
   # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies


### PR DESCRIPTION
## Motivation / Issue
After trying to install a new package from composer [PHPMatcher](https://github.com/coduo/php-matcher), it requires the intl extension.

