### PR TITLE
add a docker-compose argument DRUSH_FILE

### DIFF
--- a/scripts/docker-as-drupal
+++ b/scripts/docker-as-drupal
@@ -13,6 +13,7 @@ set -e
 : ${SITE_INSTALL_PROFILE:="standard"}
 : ${PRIVATE_FILES:=""}
 : ${SERVICES_FILE:=""}
+: ${DRUSH_FILE:=""}
 : ${DEFAULT_CONTENT:=""}
 : ${REQUIRED_DIRECTORIES:="/var/www/log/behat"}
 : ${LOG_DIR:="/var/www/log"}
@@ -176,6 +177,12 @@ function setup() {
   if [ ! -z "$SERVICES_FILE" ] && [ -f "$SERVICES_FILE" ] ; then
     printf "\e[1;35m* Copy services.yml file.\e[0m\n"
     cp $SERVICES_FILE ./web/sites/default/services.yml
+  fi
+
+  # Setup drush.yml file
+  if [ ! -z "$DRUSH_FILE" ] && [ -f "$DRUSH_FILE" ] ; then
+    printf "\e[1;35m* Copy drush.yml file.\e[0m\n"
+    mkdir -p "./drush" && cp $DRUSH_FILE ./drush/drush.yml
   fi
 
   printf "\e[1;35m* Update settings.php file.\e[0m\n"


### PR DESCRIPTION
allow per-docker configurations of drush.

This change is need to progress on antistatique/cardis-server#89

To tests it, pull this branch and add the following code in your project `docker-compose.override.yml` file

```
  test:
    hostname: test
    volumes:
      # Override docker-as-drupal for development purpose
      - /PATH/TO/LOCAL/REPOSITORY/docker-php-dev/scripts/docker-as-drupal:/usr/local/bin/docker-as-drupal
```

Then you will need to add the following line in your `docker-compose.yml`

```
  # Drupal test server
  test:
    (...)
    environment:
      BASE_URL: http://localhost:8888
      (...)
      DRUSH_FILE: /var/www/config/d8/docker.drush.yml
    (...)
```

Here an example of `drush.yml`

```
options:
  uri: '${env.BASE_URL}'
```

Then you can test it by executing a `drush status` on the proper docker. Then, the *Site URI* should be the one you specify in your `drush.yml` instead of basic `http://default`.

```
root@test:/var/www# drush st
 Drupal version   : 8.8.1
 Site URI         : http://localhost:8888
```