### PR TITLE
[drupal] settings.php look for settings per env and for local settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Following environement variable are available:
 ```bash
 APACHE_DOCUMENT_ROOT          # Apache Document Root (default to "/var/www/web")
 
+APP_ENV                       # Eq: development, test, production. This environment variable
+                              # is used to load specific settings per environment.
+
 DATABASE_URL                  # Database URL scheme, should be different for dev and test services
 DATABASE_DUMP                 # Database dump file path (default to "/var/backups/db-reset.sql"). Must
                               # be located in a volume shared by dev and test services.
@@ -109,6 +112,7 @@ services:
       - db
       - mail
     environment:
+      APP_ENV: development
       DATABASE_URL: mysql://drupal:drupal@db/drupal_development
       PRIVATE_FILES: /var/www/web/sites/default/files/private
       DEFAULT_CONTENT: project_default_content
@@ -127,6 +131,7 @@ services:
       - db
       - mail
     environment:
+      APP_ENV: test
       DATABASE_URL: mysql://drupal:drupal@db/drupal_test
       PRIVATE_FILES: /var/www/web/sites/default/files/private
       DEFAULT_CONTENT: project_default_content
@@ -161,6 +166,20 @@ volumes:
   database:
   backups:
 ```
+
+**settings.php files**
+You can create different PHP settings file based on the `APP_ENV` environment.
+The format is `${APP_ENV}.settings.php`:
+
+```
+# ./web/sites/default/development.settings.php
+
+$settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
+$config['backerymails.settings']['reroute']['status'] = TRUE;
+// ...
+```
+
+Finally, a local settings PHP file is loaded if you create the script `./web/sites/default/settings.local.php`.
 
 Use `docker-compose up` to start services then following command to boostrap (or reset) the
 Drupal installation: `docker-compose exec dev docker-as-drupal bootstrap`. Test service must

--- a/php/5.6/node/8/scripts/docker-as-drupal
+++ b/php/5.6/node/8/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/5.6/scripts/docker-as-drupal
+++ b/php/5.6/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.0/node/10/scripts/docker-as-drupal
+++ b/php/7.0/node/10/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.0/node/8/scripts/docker-as-drupal
+++ b/php/7.0/node/8/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.0/scripts/docker-as-drupal
+++ b/php/7.0/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.1/node/10/scripts/docker-as-drupal
+++ b/php/7.1/node/10/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.1/node/11/scripts/docker-as-drupal
+++ b/php/7.1/node/11/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.1/node/12/scripts/docker-as-drupal
+++ b/php/7.1/node/12/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.1/node/6/scripts/docker-as-drupal
+++ b/php/7.1/node/6/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.1/node/8/scripts/docker-as-drupal
+++ b/php/7.1/node/8/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.1/node/9/scripts/docker-as-drupal
+++ b/php/7.1/node/9/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.1/scripts/docker-as-drupal
+++ b/php/7.1/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.2/node/10/scripts/docker-as-drupal
+++ b/php/7.2/node/10/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.2/node/11/scripts/docker-as-drupal
+++ b/php/7.2/node/11/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.2/node/12/scripts/docker-as-drupal
+++ b/php/7.2/node/12/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.2/node/8/scripts/docker-as-drupal
+++ b/php/7.2/node/8/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.2/node/9/scripts/docker-as-drupal
+++ b/php/7.2/node/9/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.2/scripts/docker-as-drupal
+++ b/php/7.2/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.3/node/10/scripts/docker-as-drupal
+++ b/php/7.3/node/10/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.3/node/11/scripts/docker-as-drupal
+++ b/php/7.3/node/11/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.3/node/12/scripts/docker-as-drupal
+++ b/php/7.3/node/12/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/php/7.3/scripts/docker-as-drupal
+++ b/php/7.3/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 

--- a/scripts/docker-as-drupal
+++ b/scripts/docker-as-drupal
@@ -254,6 +254,22 @@ function setup() {
     find "$PRIVATE_FILES" -type d -exec chmod +xs {} \;
   fi
 
+  # Include environement and local settings if they exists
+  if ! grep -Eq "[INCLUDE] Environment specific settings files." ./web/sites/default/settings.php; then
+    cat <<EOT >> ./web/sites/default/settings.php
+// [INCLUDE] Environment specific settings files.
+if (getenv('APP_ENV')) {
+  if (file_exists(__DIR__ . '/' . getenv('APP_ENV') . '.settings.php')) {
+    include __DIR__ . '/' . getenv('APP_ENV') . '.settings.php';
+  }
+}
+// Last: this servers specific settings files.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+EOT
+  fi
+
   # Create required directories
   printf "\e[1;35m* Setup required directories.\e[0m\n"
 


### PR DESCRIPTION
### 💬 Describe the pull request
This is my first attempt to reduce the complexity of `docker-as-drupal` script.
The next step will be remove all `settings.php` manipulation and to use only environement variable + committed settings.php.

This PR add the support of a new environment variable named `APP_ENV`.
`APP_ENV` can have the following value: `development`, `test`, `production`.

If this env var exists the `settings.php` will look for other configuration file based on the value of `APP_ENV`:
 - `./web/sites/default/development.settings.php`
 - `./web/sites/default/test.settings.php`
 - `./web/sites/default/production.settings.php`

Lastly, `settings.php` will load a local file (if present):

 - `./web/sites/default/settings.local.php`


### 🗃️ Issues
With this simple change, we can reduce the complexity added PR, after PR. Like in

- #21
- #25 
- #28
- #27 
- antistatique/cardis-server#156