### PR TITLE
ensure the unzip bin is available on PATH

### DIFF
--- a/php/tests/baseCommandTests.yaml
+++ b/php/tests/baseCommandTests.yaml
@@ -1,0 +1,6 @@
+schemaVersion: '2.0.0'
+commandTests:
+  - name: "Unzip"
+    command: "which"
+    args: ["unzip"]
+    expectedOutput: ["/usr/bin/unzip"]

--- a/test.sh
+++ b/test.sh
@@ -98,6 +98,9 @@ function test {
     # Ensure base file existences.
     container-structure-test test --image antistatique/php-dev:${TAG} --config ${scriptDir}/php/tests/baseFileExistenceTests.yaml
 
+    # Ensure base commands.
+    container-structure-test test --image antistatique/php-dev:${TAG} --config ${scriptDir}/php/tests/baseCommandTests.yaml
+
     # Image specific structure testing.
     container-structure-test test --image antistatique/php-dev:${TAG} --config ${scriptDir}/php/$1/tests/config--${TAG}.yaml
   )


### PR DESCRIPTION
### 💬 Describe the pull request

As explain by Composer maintainers, unzip may be used to improve performances during Composer install (during unpack phase).