### PR TITLE
Add apache headers module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex; \
   if command -v a2enmod; then \
     a2enmod rewrite; \
     a2enmod headers; \
+    a2enmod expires; \
   fi; \
   \
   savedAptMark="$(apt-mark showmanual)"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex; \
   \
   if command -v a2enmod; then \
     a2enmod rewrite; \
+    a2enmod headers; \
   fi; \
   \
   savedAptMark="$(apt-mark showmanual)"; \


### PR DESCRIPTION
### 💬 Describe the pull request
Our current image don't include the headers module for Apache:

```
 $ apache2ctl -M
```

It's commun to have it enabled on production.