### PR TITLE
Remove /var/www/vendor/bin from the PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM php:%%PHP_VERSION%%-apache
 ENV APACHE_DOCUMENT_ROOT /var/www/web
 ENV NODE_MAJOR_VERSION %%NODE_VERSION%%
 
-ENV PATH="/var/www/node_modules/.bin:/var/www/vendor/bin:/var/www/bin:${PATH}"
+ENV PATH="${PATH}:/var/www/node_modules/.bin:/var/www/vendor/bin:/var/www/bin"
 ENV ARTIFACTS_DEST="/usr/bin/artifacts"
 
 ENV COMPOSER_MEMORY_LIMIT=-1

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM php:%%PHP_VERSION%%-apache
 ENV APACHE_DOCUMENT_ROOT /var/www/web
 ENV NODE_MAJOR_VERSION %%NODE_VERSION%%
 
-ENV PATH="${PATH}:/var/www/node_modules/.bin:/var/www/vendor/bin:/var/www/bin"
+ENV PATH="/var/www/node_modules/.bin:/var/www/bin:${PATH}"
 ENV ARTIFACTS_DEST="/usr/bin/artifacts"
 
 ENV COMPOSER_MEMORY_LIMIT=-1

--- a/tests/baseMetadataTests.yaml
+++ b/tests/baseMetadataTests.yaml
@@ -6,7 +6,7 @@ metadataTest:
     - key: 'APACHE_DOCUMENT_ROOT'
       value: '/var/www/web'
     - key: 'PATH'
-      value: '/var/www/node_modules/.bin:/var/www/vendor/bin:/var/www/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+      value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/www/node_modules/.bin:/var/www/vendor/bin:/var/www/bin'
     - key: 'ARTIFACTS_DEST'
       value: '/usr/bin/artifacts'
   volumes: ["/var/backups"]

--- a/tests/baseMetadataTests.yaml
+++ b/tests/baseMetadataTests.yaml
@@ -6,7 +6,7 @@ metadataTest:
     - key: 'APACHE_DOCUMENT_ROOT'
       value: '/var/www/web'
     - key: 'PATH'
-      value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/www/node_modules/.bin:/var/www/vendor/bin:/var/www/bin'
+      value: '/var/www/node_modules/.bin:/var/www/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
     - key: 'ARTIFACTS_DEST'
       value: '/usr/bin/artifacts'
   volumes: ["/var/backups"]


### PR DESCRIPTION
This fix some strange behavior when we have package that require composer itself and have `/var/www/vendor/bin/composer` defined (which could be very different from the one expected `/usr/local/bin/composer`).

This change could generate BC break.
What do you think?

(I my opinion we should not alter the `PATH` in the base image at all)

