### PR TITLE
typo 'mayn' -> 'many'

### DIFF
--- a/scripts/docker-as-wait
+++ b/scripts/docker-as-wait
@@ -14,7 +14,7 @@ WAITFORIT_PIDS=()
 function print_help() {
   echo "usage: $SCRIPT_NAME [options]
 
-    --wait   # How mayn seconds to wait before exit with error
+    --wait   # How many seconds to wait before exit with error
 
   * services:
     --mysql       # Wait until MySQL is ready


### PR DESCRIPTION
### 💬 Describe the pull request/code changes
_A clear and concise description of what the pull request is about._
fix typo typo 'mayn' -> 'many' on `docker-as-wait`